### PR TITLE
LeaseTime 초과 시 트랜잭션 롤백하도록 수정

### DIFF
--- a/Tradin-Core/src/main/java/com/tradin/core/account/service/AccountFacadeService.java
+++ b/Tradin-Core/src/main/java/com/tradin/core/account/service/AccountFacadeService.java
@@ -7,8 +7,6 @@ import com.tradin.core.balance.service.BalanceService;
 import com.tradin.core.common.annotation.DistributedLock;
 import com.tradin.core.strategy.domain.CoinType;
 import com.tradin.core.account.domain.Account;
-import com.tradin.core.strategy.domain.Position;
-import com.tradin.core.strategy.domain.Strategy;
 import com.tradin.core.users.domain.Users;
 import com.tradin.core.users.service.UsersService;
 import java.math.BigDecimal;

--- a/Tradin-Core/src/main/java/com/tradin/core/common/annotation/DistributedLock.java
+++ b/Tradin-Core/src/main/java/com/tradin/core/common/annotation/DistributedLock.java
@@ -28,7 +28,7 @@ public @interface DistributedLock {
     /**
      * 락 임대 시간 (default - 3s) 락을 획득한 이후 leaseTime 이 지나면 락을 해제한다
      */
-    long leaseTime() default 3L;
+    int leaseTime() default 3;
 
     String fallbackMethod() default "";
 

--- a/Tradin-Core/src/main/java/com/tradin/core/common/aop/AopForTransaction.java
+++ b/Tradin-Core/src/main/java/com/tradin/core/common/aop/AopForTransaction.java
@@ -1,14 +1,21 @@
 package com.tradin.core.common.aop;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
 
 @Component
+@RequiredArgsConstructor
 @Slf4j
 public class AopForTransaction {
+    private final PlatformTransactionManager transactionManager;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public Object proceed(final ProceedingJoinPoint joinPoint) throws Throwable {
@@ -22,8 +29,36 @@ public class AopForTransaction {
                 throwable
             );
             throw throwable;
-        } finally {
-//            log.info("🔓 트랜잭션 종료 - method: {}", joinPoint.getSignature().getName());
+        }
+    }
+
+    /**
+     * 트랜잭션을 새로 생성하고, 지정된 시간(초) 내에 완료되지 않으면 롤백합니다.
+     */
+    public Object proceedWithTimeout(final ProceedingJoinPoint joinPoint, int timeoutSeconds) throws Throwable {
+        DefaultTransactionDefinition transactionDefinition = new DefaultTransactionDefinition();
+        transactionDefinition.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+
+        if (timeoutSeconds > 0) {
+            transactionDefinition.setTimeout(timeoutSeconds);
+        }
+
+        TransactionStatus transactionStatus = transactionManager.getTransaction(transactionDefinition);
+
+        try {
+            Object result = joinPoint.proceed();
+            transactionManager.commit(transactionStatus);
+            return result;
+        } catch (Throwable throwable) {
+            transactionManager.rollback(transactionStatus);
+            log.error(
+                "🚫 트랜잭션 처리 중 오류 발생 - method: {}, timeout: {}s, error: {}",
+                joinPoint.getSignature().getName(),
+                timeoutSeconds,
+                throwable.getMessage(),
+                throwable
+            );
+            throw throwable;
         }
     }
 }

--- a/Tradin-Core/src/main/java/com/tradin/core/common/aop/DistributedLockAop.java
+++ b/Tradin-Core/src/main/java/com/tradin/core/common/aop/DistributedLockAop.java
@@ -30,7 +30,6 @@ public class DistributedLockAop {
     @Around("@annotation(distributedLock)")
     public Object handleDistributedLock(ProceedingJoinPoint joinPoint, DistributedLock distributedLock) throws Throwable {
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
-        Method method = signature.getMethod();
 
         String key = createKey(joinPoint, distributedLock, signature);
         RLock lock = redissonClient.getLock(key);
@@ -38,29 +37,27 @@ public class DistributedLockAop {
         boolean isLocked = false;
 
         try {
-            isLocked = lock.tryLock(distributedLock.waitTime(), distributedLock.leaseTime(), distributedLock.timeUnit());
+            isLocked = lock.tryLock(distributedLock.waitTime(), -1L, distributedLock.timeUnit());
 
             if (!isLocked) {
                 log.warn("🔒 락 획득 실패 - key: {}", key);
                 return invokeFallback(joinPoint, distributedLock.fallbackMethod());
             }
 
-//            log.info("🔐 락 획득 성공 - key: {}", key);
-            return aopForTransaction.proceed(joinPoint);
+            try {
+                Object result = aopForTransaction.proceedWithTimeout(joinPoint, distributedLock.leaseTime());
+                releaseLock(lock, key);
+                return result;
+            } catch (Throwable throwable) {
+                releaseLock(lock, key);
+                throw throwable;
+            }
 
         } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
             log.error("🚫 락 처리 중 인터럽트 발생 - key: {}", key, e);
+            Thread.currentThread().interrupt();
+            releaseLock(lock, key);
             return invokeFallback(joinPoint, distributedLock.fallbackMethod());
-        } finally {
-            if (isLocked && lock.isHeldByCurrentThread()) {
-                try {
-                    lock.unlock();
-//                    log.info("🔓 락 해제 - key: {}", key);
-                } catch (IllegalMonitorStateException e) {
-//                    log.warn("⚠️ 락 이미 해제됨 - method: {}, key: {}", method.getName(), key);
-                }
-            }
         }
     }
 
@@ -105,5 +102,19 @@ public class DistributedLockAop {
             }
         }
         return null;
+    }
+
+    private void releaseLock(RLock lock, String key) {
+        if (lock.isHeldByCurrentThread()) {
+            try {
+                lock.unlock();
+            } catch (IllegalMonitorStateException e) {
+                log.warn("⚠️ 락 이미 해제됨 - key: {}", key);
+            } catch (Exception e) {
+                log.error("🚫 락 해제 실패 - key: {}, error: {}", key, e.getMessage());
+            }
+        } else {
+            log.warn("⚠️ 현재 스레드가 락을 소유하지 않음 - key: {}", key);
+        }
     }
 }

--- a/Tradin-Core/src/main/java/com/tradin/core/futuresOrder/service/FuturesOrderFacadeService.java
+++ b/Tradin-Core/src/main/java/com/tradin/core/futuresOrder/service/FuturesOrderFacadeService.java
@@ -1,5 +1,7 @@
 package com.tradin.core.futuresOrder.service;
 
+import static java.lang.Thread.sleep;
+
 import com.tradin.core.account.domain.Account;
 import com.tradin.core.balance.domain.Balance;
 import com.tradin.core.balance.domain.vo.Amount;
@@ -29,7 +31,6 @@ public class FuturesOrderFacadeService {
         key = "'asset-lock:' + #account.id + ':USDT'",
         fallbackMethod = "handleAssetLockFallback"
     )
-    @Transactional
     public void autoTrade(Strategy strategy, Account account, Position position) {
         try {
             closeExistingPositionIfExists(strategy, account);


### PR DESCRIPTION
## 변경사항
- 트랜잭션이 락 임대 시간보다 길게 수행되는 경우 해당 트랜잭션을 롤백 처리하도록 수정

## 상세내용
- 최초에는 트랜잭션 처리 중 분산락 만료 시 연장을 통해 롤백 시점까지 유지하려 했으나, Redisson에서는 락 만료 이벤트를 직접 감지할 수 없었습니다. 따라서 Spring의 트랜잭션 timeout 기능을 활용하여, 지정된 시간이 초과되면 트랜잭션을 롤백하고 롤백 완료 후 락을 해제하도록 개선했습니다.
  - WatchDog 기능을 활용하여 분산락 지속 연장
  - `AopForTransaction`에 `@Transactional` 어노테이션 대신 `PlatformTransactionManager`를 직접 사용함으로써 트랜잭션이 LeaseTime보다 길게 수행되는 경우 해당 트랜잭션을 롤백하고 롤백 완료 시 락을 해제하도록 개선
 
### 예시
기존 : A 트랜잭션 수행 도중 분산락 임대 시간 초과로 락 해제되면 B 트랜잭션에서 분산락 획득 및 Dirty Read 발생 가능
현재 : A 트랜잭션 수행 도중 임대 시간 초과되면 분산락을 유지한 상태로 트랜잭션 롤백 수행 -> B 트랜잭션은 락 획득 대기


## 연관 이슈
- close #45 