### PR TITLE
인덱스 최적화

### DIFF
--- a/Tradin-Core/src/main/java/com/tradin/core/account/domain/Account.java
+++ b/Tradin-Core/src/main/java/com/tradin/core/account/domain/Account.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Index;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -24,9 +25,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(indexes = {
-    @Index(name = "idx_account_user_id", columnList = "user_id"),
-    @Index(name = "idx_account_is_deleted", columnList = "is_deleted"),
-    @Index(name = "idx_account_user_deleted", columnList = "user_id, is_deleted")
+    @Index(name = "ix_account_user_is_deleted", columnList = "user_id, is_deleted")
 })
 public class Account extends AuditTime {
 

--- a/Tradin-Core/src/main/java/com/tradin/core/balance/domain/Balance.java
+++ b/Tradin-Core/src/main/java/com/tradin/core/balance/domain/Balance.java
@@ -23,6 +23,8 @@ import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Index;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,11 +33,10 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "balance", indexes = {
-    @Index(name = "idx_balance_account_id", columnList = "account_id"),
-    @Index(name = "idx_balance_coin_type", columnList = "coin_type"),
-    @Index(name = "idx_balance_account_coin", columnList = "account_id, coin_type")
-})
+@Table(
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_balance_account_coin_type", columnNames = {"account_id", "coin_type"})
+    })
 public class Balance extends AuditTime {
 
     @Id

--- a/Tradin-Core/src/main/java/com/tradin/core/futuresOrder/domain/FuturesOrder.java
+++ b/Tradin-Core/src/main/java/com/tradin/core/futuresOrder/domain/FuturesOrder.java
@@ -24,6 +24,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.Index;
+import jakarta.persistence.Index;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import lombok.AccessLevel;
@@ -35,11 +36,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(indexes = {
-    @Index(name = "idx_futures_order_account_id", columnList = "account_id"),
-    @Index(name = "idx_futures_order_strategy_id", columnList = "strategy_id"),
-    @Index(name = "idx_futures_order_status", columnList = "order_status"),
-    @Index(name = "idx_futures_order_created_at", columnList = "created_at"),
-    @Index(name = "idx_futures_order_account_strategy", columnList = "account_id, strategy_id")
+    @Index(name = "ix_futures_order_account_strategy", columnList = "account_id, strategy_id")
 })
 public class FuturesOrder extends AuditTime {
 

--- a/Tradin-Core/src/main/java/com/tradin/core/futuresPosition/domain/FuturesPosition.java
+++ b/Tradin-Core/src/main/java/com/tradin/core/futuresPosition/domain/FuturesPosition.java
@@ -24,6 +24,7 @@ import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Index;
 import jakarta.persistence.UniqueConstraint;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -37,10 +38,11 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(
-    uniqueConstraints = @UniqueConstraint(columnNames = {"account_id", "coinType"}),
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_futures_position_account_coin_type", columnNames = {"account_id", "coin_type"})
+    },
     indexes = {
-        @Index(name = "idx_futures_position_account_coin", columnList = "account_id, coinType"),
-        @Index(name = "idx_futures_position_created_at", columnList = "created_at")
+        @Index(name = "ix_futures_position_coin_type_liquidation_price", columnList = "coin_type, liquidation_price")
     }
 )
 public class FuturesPosition extends AuditTime {

--- a/Tradin-Core/src/main/java/com/tradin/core/history/domain/History.java
+++ b/Tradin-Core/src/main/java/com/tradin/core/history/domain/History.java
@@ -21,6 +21,7 @@ import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Index;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,12 +29,10 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(indexes = {
-    @Index(name = "idx_history_strategy_id", columnList = "strategy_id"),
-    @Index(name = "idx_history_created_at", columnList = "created_at"),
-    @Index(name = "idx_history_strategy_created", columnList = "strategy_id, created_at")
-})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(indexes = {
+    @Index(name = "idx_history_strategy_exit", columnList = "strategy_id, exit_time DESC")
+})
 public class History extends AuditTime {
 
     @Id

--- a/Tradin-Core/src/main/java/com/tradin/core/outbox/domain/OutboxMessage.java
+++ b/Tradin-Core/src/main/java/com/tradin/core/outbox/domain/OutboxMessage.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Index;
+import jakarta.persistence.Index;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,13 +21,9 @@ import org.hibernate.annotations.Type;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "outbox_message", indexes = {
-    @Index(name = "idx_outbox_message_type", columnList = "message_type"),
-    @Index(name = "idx_outbox_message_id", columnList = "message_id"),
-    @Index(name = "idx_outbox_status", columnList = "status"),
-    @Index(name = "idx_outbox_type_status", columnList = "message_type, status"),
-    @Index(name = "idx_outbox_created_at", columnList = "created_at"),
-    @Index(name = "idx_outbox_updated_at", columnList = "updated_at")
+@Table(indexes = {
+    @Index(name = "idx_outbox_message_type_status", columnList = "message_type, status"),
+    @Index(name = "idx_outbox_message_id", columnList = "message_id")
 })
 public class OutboxMessage extends AuditTime {
 

--- a/Tradin-Core/src/main/java/com/tradin/core/strategy/domain/Strategy.java
+++ b/Tradin-Core/src/main/java/com/tradin/core/strategy/domain/Strategy.java
@@ -24,14 +24,6 @@ import jakarta.persistence.Index;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(indexes = {
-    @Index(name = "idx_strategy_name", columnList = "name"),
-    @Index(name = "idx_strategy_type_strategy", columnList = "strategy_type"),
-    @Index(name = "idx_strategy_type_coin", columnList = "coin_type"),
-    @Index(name = "idx_strategy_type_timeframe", columnList = "time_frame_type"),
-    @Index(name = "idx_strategy_profit_factor", columnList = "profit_factor"),
-    @Index(name = "idx_strategy_created_at", columnList = "created_at")
-})
 public class Strategy extends AuditTime {
 
     @Id

--- a/Tradin-Core/src/main/java/com/tradin/core/subscription/domain/Subscription.java
+++ b/Tradin-Core/src/main/java/com/tradin/core/subscription/domain/Subscription.java
@@ -16,6 +16,7 @@ import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Index;
 import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
@@ -27,14 +28,11 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(
-    uniqueConstraints = @UniqueConstraint(columnNames = {"account_id", "strategy_id"}),
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_subscription_strategy_account", columnNames = {"strategy_id", "account_id"})
+    },
     indexes = {
-        @Index(name = "idx_subscription_account_id", columnList = "account_id"),
-        @Index(name = "idx_subscription_strategy_id", columnList = "strategy_id"),
-        @Index(name = "idx_subscription_status", columnList = "status"),
-        @Index(name = "idx_subscription_strategy_status", columnList = "strategy_id, status"),
-        @Index(name = "idx_subscription_start_date", columnList = "start_date"),
-        @Index(name = "idx_subscription_end_date", columnList = "end_date")
+        @Index(name = "ix_subscription_strategy_status_account", columnList = "strategy_id, status, account_id")
     }
 )
 public class Subscription extends AuditTime {
@@ -44,12 +42,12 @@ public class Subscription extends AuditTime {
     private Long id;
 
     @ManyToOne
-    @JoinColumn(name = "account_id", nullable = false)
-    private Account account;
-
-    @ManyToOne
     @JoinColumn(name = "strategy_id", nullable = false)
     private Strategy strategy;
+
+    @ManyToOne
+    @JoinColumn(name = "account_id", nullable = false)
+    private Account account;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/Tradin-Core/src/main/java/com/tradin/core/users/domain/Users.java
+++ b/Tradin-Core/src/main/java/com/tradin/core/users/domain/Users.java
@@ -23,8 +23,8 @@ import org.springframework.security.core.userdetails.UserDetails;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(indexes = {
-    @Index(name = "idx_users_email", columnList = "email"),
-    @Index(name = "idx_users_sub", columnList = "sub")
+    @Index(name = "ix_users_email", columnList = "email"),
+    @Index(name = "ix_users_sub", columnList = "sub")
 })
 public class Users extends AuditTime implements UserDetails {
 


### PR DESCRIPTION
## 변경사항
- 시스템 구조에 맞도록 인덱스 최적화

## 상세내용
🏦 Account
- 인덱스: user_id, is_deleted
  - 유저의 전체 계좌 조회, 유저별 활성 계좌 조회 등의 쿼리 패턴에 적합

💰 Balance
- 인덱스: account_id, coin_type (Unique Constraint)
  - 계좌 당 코인 잔고는 유니크
  - 계좌별 전체 잔고 조회, 계좌별 코인 잔고 조회 쿼리 패턴에 적합.

📋 FuturesOrder
- 인덱스: account_id, strategy_id
  - 계좌별 주문내역 조회 등의 쿼리 패턴에 적합

📈 FuturesPosition
- 인덱스: account_id, coin_type (Unique Constraint)
  - 계좌 당 코인 포지션은 유니크
  - 계좌별 포지션 조회 등의 쿼리 패턴에 적합

- 인덱스: coin_type, liquidation_price
  - 강제 청산 모니터링 시 적합

📊 History
- 인덱스: strategy_id, exit_time DESC
  - 전략별 최근 거래내역 조회 쿼리 패턴에 적합
  - 백테스트 시 전략별 거래내역 전체를 캐시한 뒤, 서버에서 필터링 하기 때문에 추가 조건은 불필요하다고 판단

📤 OutboxMessage
- 인덱스: message_type, status
  - 메시지 타입별(자동매매, 시세 업데이트, 회원가입 등) 상태 조회 쿼리 패턴에 적합

- 인덱스: message_id
  - IN절을 통해 여러 메시지 Id 조회 쿼리 패턴에 적합

🎯 Strategy
 - 인덱스: 없음
  - 데이터 건수가 10개 미만이므로 PK인덱스로 충분

🔔 Subscription
- 인덱스: strategy_id, account_id (Unique Constraint)
   - 전략 당 계좌는 유니크

- 인덱스: strategy_id, status, account_id
   - 전략별 활성 구독 계좌 조회 쿼리 패턴에 적합

👤 User
 - 인덱스: email / sub
   - 로그인 및 OAuth 인증 시 이메일/SUB 조회 최적화

## 연관 이슈
- close #47 